### PR TITLE
Add new Info page with build and dependency details

### DIFF
--- a/src/pages/info.astro
+++ b/src/pages/info.astro
@@ -1,0 +1,25 @@
+---
+import Layout from '../layouts/Layout.astro';
+import pkg from '../../package.json';
+
+import { execSync } from 'child_process';
+const build = execSync('git rev-parse HEAD').toString().trim();
+const buildLink = `https://github.com/DemwE/portfolio-rework/tree/${build}`;
+---
+
+<Layout title="Info">
+    <main class="flex flex-col h-screen justify-center items-center min-w-fit">
+        <div class="rounded-2xl bg-slate-700 text-white m-auto w-1/5 min-w-fit min-h-fit px-6">
+            <div class="m-2">
+                <h1 class="text-2xl p-2 text-center">Dependencies</h1>
+                <ul class="p-4 bg-slate-800 rounded-2xl">
+                    {Object.entries(pkg.dependencies).map(([key, value]) => (
+                            <li>{key}: {value}</li>
+                    ))}
+                </ul>
+                <h1 class="p-2 text-2xl text-center">Current build: </h1>
+                <p class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center"><a href={buildLink} class="no-underline hover:underline decoration-sky-500 decoration-2" aria-label={build} target="_blank">{build}</a></p>
+            </div>
+        </div>
+    </main>
+</Layout>


### PR DESCRIPTION
Implemented a new page in the application that presents the current build and dependencies used. The page provides a list of all dependencies pulled from the package.json file. Additionally, it includes a link to the specific Github commit representing the current build of the application.