### PR TITLE
Add system and server version info on Info page

### DIFF
--- a/src/pages/info.astro
+++ b/src/pages/info.astro
@@ -17,35 +17,11 @@ try {
 } catch (error) {
     systemInfo = 'Failed to get system information';
 }
-
-// Get Nginx version
-let nginxVersion = '';
-try {
-    if (process.platform === 'win32') {
-        nginxVersion = execSync('nginx -v 2>&1', { shell: 'cmd.exe' }).toString().trim();
-    } else {
-        nginxVersion = execSync('nginx -v 2>&1').toString().trim();
-    }
-} catch (error) {
-    nginxVersion = 'Nginx not installed or not in PATH';
-}
-
-// Get Apache version
-let apacheVersion = '';
-try {
-    if (process.platform === 'win32') {
-        apacheVersion = execSync('httpd -v 2>&1', { shell: 'cmd.exe' }).toString().trim();
-    } else {
-        apacheVersion = execSync('apachectl -v 2>&1').toString().trim();
-    }
-} catch (error) {
-    apacheVersion = 'Apache not installed or not in PATH';
-}
 ---
 
 <Layout title="Info">
-    <main class="flex flex-col h-screen justify-center items-center min-w-fit">
-        <div class="rounded-2xl bg-slate-700 text-white m-auto w-1/5 min-w-fit min-h-fit px-6">
+    <main class="flex flex-col h-screen justify-center items-center">
+        <div class="rounded-2xl bg-slate-700 text-white m-auto w-1/5 min-w-[300px] min-h-fit px-6">
             <div class="m-2">
                 <h1 class="text-2xl p-2 text-center">Dependencies</h1>
                 <ul class="p-4 bg-slate-800 rounded-2xl">
@@ -57,11 +33,6 @@ try {
                 <p class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center"><a href={buildLink} class="no-underline hover:underline decoration-sky-500 decoration-2" aria-label={build} target="_blank">{build}</a></p>
                 <h1 class="p-2 text-2xl text-center">System info: </h1>
                 <p class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center">{systemInfo}</p>
-                <h1 class="p-2 text-2xl text-center">Nginx or Apache version: </h1>
-                <div class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center">
-                <p>{nginxVersion}</p>
-                <p>{apacheVersion}</p>
-                </div>
             </div>
         </div>
     </main>

--- a/src/pages/info.astro
+++ b/src/pages/info.astro
@@ -5,6 +5,42 @@ import pkg from '../../package.json';
 import { execSync } from 'child_process';
 const build = execSync('git rev-parse HEAD').toString().trim();
 const buildLink = `https://github.com/DemwE/portfolio-rework/tree/${build}`;
+
+// Get system information
+let systemInfo = '';
+try {
+    if (process.platform === 'win32') {
+        systemInfo = execSync('ver').toString().trim();
+    } else {
+        systemInfo = execSync('uname -a').toString().trim();
+    }
+} catch (error) {
+    systemInfo = 'Failed to get system information';
+}
+
+// Get Nginx version
+let nginxVersion = '';
+try {
+    if (process.platform === 'win32') {
+        nginxVersion = execSync('nginx -v 2>&1', { shell: 'cmd.exe' }).toString().trim();
+    } else {
+        nginxVersion = execSync('nginx -v 2>&1').toString().trim();
+    }
+} catch (error) {
+    nginxVersion = 'Nginx not installed or not in PATH';
+}
+
+// Get Apache version
+let apacheVersion = '';
+try {
+    if (process.platform === 'win32') {
+        apacheVersion = execSync('httpd -v 2>&1', { shell: 'cmd.exe' }).toString().trim();
+    } else {
+        apacheVersion = execSync('apachectl -v 2>&1').toString().trim();
+    }
+} catch (error) {
+    apacheVersion = 'Apache not installed or not in PATH';
+}
 ---
 
 <Layout title="Info">
@@ -19,6 +55,13 @@ const buildLink = `https://github.com/DemwE/portfolio-rework/tree/${build}`;
                 </ul>
                 <h1 class="p-2 text-2xl text-center">Current build: </h1>
                 <p class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center"><a href={buildLink} class="no-underline hover:underline decoration-sky-500 decoration-2" aria-label={build} target="_blank">{build}</a></p>
+                <h1 class="p-2 text-2xl text-center">System info: </h1>
+                <p class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center">{systemInfo}</p>
+                <h1 class="p-2 text-2xl text-center">Nginx or Apache version: </h1>
+                <div class="overflow-auto p-4 bg-slate-800 rounded-2xl text-center">
+                <p>{nginxVersion}</p>
+                <p>{apacheVersion}</p>
+                </div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
Expanded the Info page to display system information and versions of Nginx and Apache. The application will now check the platform (Windows or Unix-based) and display the appropriate system information. It will also attempt to execute commands to obtain versions of Nginx and Apache. If the commands fail, it will display an appropriate error message.